### PR TITLE
Added hollow square pattern in Python

### DIFF
--- a/src/python/hollowsquarepattern.py
+++ b/src/python/hollowsquarepattern.py
@@ -1,0 +1,16 @@
+def hollowSquare(length, width):
+    for i in range(length):
+        if i == 0 or i == length - 1:
+            print("* " * width)
+        else:
+            #The length of the spacing could also be calculated, but this is a basic implementation
+            output = ""
+            for j in range(width):
+                if j == 0 or j == width - 1:
+                    output += "* "
+                else:
+                    output += "  "
+            print(output)
+
+
+hollowSquare(5, 5)


### PR DESCRIPTION
- Patter is valid with integer values 0 or greater.
- '*' will only show if the length and width are both 1 or greater.
- The hollow center is not apparent unless the length and width are both 3 or greater.
- Even with a width of 0, a series of blank lines will be printed to represent the given length